### PR TITLE
RM-7179: Enable STRIP_strip option for the FDPIC bin format.

### DIFF
--- a/Config.in
+++ b/Config.in
@@ -434,7 +434,7 @@ config BR2_ENABLE_RUNTIME_DEBUG
 config BR2_STRIP_strip
 	bool "strip target binaries"
 	default y
-	depends on BR2_BINFMT_ELF
+	depends on (BR2_BINFMT_ELF || BR2_BINFMT_FDPIC)
 	help
 	  Binaries and libraries in the target filesystem will be
 	  stripped using the normal 'strip' command. This allows to save


### PR DESCRIPTION
Unit test:

Build SDK 
verify that libraries in the output/target directory have reduced size
verify that stripped version of the libraries are working on the target (IMXRT1050-EVK)