### PR TITLE
RM7326:  support FDPIC core dump debugging

### DIFF
--- a/package/gdb/11.2/0020-RM-7623-bfd-elf32-arm-recognize-FDPIC-prstatus-in-core-dumps.patch
+++ b/package/gdb/11.2/0020-RM-7623-bfd-elf32-arm-recognize-FDPIC-prstatus-in-core-dumps.patch
@@ -1,0 +1,47 @@
+From: Vladimir Skvortsov <vskvortsov@emcraft.com>
+Subject: [PATCH] RM-7623: bfd: recognize FDPIC-extended NT_PRSTATUS in ARM core dumps
+
+The Linux kernel writes `struct elf_prstatus_fdpic`
+(fs/binfmt_elf_fdpic.c) for FDPIC processes, which appends
+pr_exec_fdpic_loadmap and pr_interp_fdpic_loadmap (2 * 4 bytes)
+between pr_reg and pr_fpvalid, making the NT_PRSTATUS note 156 bytes
+instead of the standard 148.  Without recognising descsz == 156 BFD
+rejects the note and no .reg pseudosection is created; GDB then
+reports:
+
+    warning: Couldn't find general-purpose registers in core file.
+
+Accept the extended layout and size the .reg pseudosection at
+72 + 4 + 4 = 80 bytes, so the two loadmap addresses sit at offsets
+72 and 76 within .reg.  Companion changes in gdb/solib-fdpic.c will
+read them via bfd_get_section_contents().  This mirrors the scheme
+used by FRV-FDPIC in bfd/elf32-frv.c.
+
+Signed-off-by: Vladimir Skvortsov <vskvortsov@emcraft.com>
+---
+--- a/bfd/elf32-arm.c
++++ b/bfd/elf32-arm.c
+@@ -2163,6 +2163,21 @@
+ 	size = 72;
+ 
+ 	break;
++
++      case 156:		/* Linux/ARM FDPIC (struct elf_prstatus_fdpic).
++			   Standard prstatus plus pr_exec_fdpic_loadmap and
++			   pr_interp_fdpic_loadmap (2 * 4 bytes) inserted
++			   between pr_reg and pr_fpvalid.  Exposing them as
++			   the tail of the .reg pseudosection lets
++			   solib-fdpic read the loadmap addresses the same
++			   way FRV-FDPIC does in bfd/elf32-frv.c.  */
++	elf_tdata (abfd)->core->signal
++	  = bfd_get_16 (abfd, note->descdata + 12);
++	elf_tdata (abfd)->core->lwpid
++	  = bfd_get_32 (abfd, note->descdata + 24);
++	offset = 72;
++	size   = 72 + 4 + 4;	/* pr_reg + exec + interp loadmap addrs */
++	break;
+     }
+ 
+   /* Make a ".reg/999" section.  */
+-- 
+2.34.1

--- a/package/gdb/11.2/0021-RM-7623-gdb-solib-fdpic-read-loadmap-from-core-dumps.patch
+++ b/package/gdb/11.2/0021-RM-7623-gdb-solib-fdpic-read-loadmap-from-core-dumps.patch
@@ -1,0 +1,117 @@
+From: Vladimir Skvortsov <vskvortsov@emcraft.com>
+Subject: [PATCH] RM-7623: gdb/solib-fdpic: read initial loadmap from core dumps
+
+For a live inferior, fdpic_get_initial_loadmaps() retrieves the
+main-executable and dynamic-linker loadmaps via
+target_read_alloc (TARGET_OBJECT_FDPIC, ...), which is served by
+gdbserver (see 0012-ARM-FDPIC-Add-gdbserver-support.patch).  For
+core files there is no such backend, so post-mortem sessions
+ended with "No shared libraries loaded at this time" and empty
+backtraces.
+
+The companion BFD change (0020-...) makes the FDPIC-extended
+NT_PRSTATUS note visible: BFD now creates an 80-byte .reg section
+whose tail holds pr_exec_fdpic_loadmap at offset 72 and
+pr_interp_fdpic_loadmap at offset 76.  Read those pointers and
+hand them to the existing fetch_loadmap() helper, which pulls the
+raw loadmap from the core's PT_LOAD segments via
+target_read_memory().
+
+Also soften the early return introduced in
+0019-rm7087-workaround-for-issue-for-file-exec-and-symbols-command.patch.
+That guard skipped relocation when there was no running inferior,
+which is still correct for "file <exec>" with no target, but
+blocks the new core-file path.  Allow the function to proceed
+when a core_bfd is present.
+
+Signed-off-by: Vladimir Skvortsov <vskvortsov@emcraft.com>
+---
+--- a/gdb/solib-fdpic.c
++++ b/gdb/solib-fdpic.c
+@@ -393,18 +393,70 @@
+   return lm_info;
+ }
+ 
++/* For core dumps the loadmap bytes are not available through
++   TARGET_OBJECT_FDPIC.  The Linux kernel instead records the addresses
++   of the exec and interpreter loadmaps in the FDPIC-extended NT_PRSTATUS
++   note (struct elf_prstatus_fdpic in fs/binfmt_elf_fdpic.c).  The BFD
++   backend (bfd/elf32-arm.c, case 156) exposes them as the tail of the
++   .reg pseudosection, so we can retrieve them with
++   bfd_get_section_contents().  Returns 0 on any failure, which the
++   caller treats as "no loadmap available" (i.e. static binary for the
++   interpreter query).  */
++
++static CORE_ADDR
++fdpic_core_loadmap_addr (int is_interpreter)
++{
++  if (core_bfd == NULL)
++    return 0;
++
++  asection *reg_sect = bfd_get_section_by_name (core_bfd, ".reg");
++  if (reg_sect == NULL)
++    return 0;
++
++  /* Stock ARM .reg is 72 bytes; FDPIC-extended .reg is 80.  */
++  if (bfd_section_size (reg_sect) < 72 + 4 + 4)
++    return 0;
++
++  gdb_byte buf[4];
++  file_ptr off = is_interpreter ? 76 : 72;
++  if (!bfd_get_section_contents (core_bfd, reg_sect, buf, off, sizeof buf))
++    return 0;
++
++  enum bfd_endian byte_order = gdbarch_byte_order (target_gdbarch ());
++  return extract_unsigned_integer (buf, sizeof buf, byte_order);
++}
++
+ static struct int_elf32_fdpic_loadmap *
+ fdpic_get_initial_loadmaps (int is_interpreter)
+ {
++  if (solib_fdpic_debug)
++    fprintf_unfiltered (gdb_stdlog, "  %s : %d\n", __FUNCTION__, is_interpreter);
++
++  /* Core-file path: only the loadmap *address* is in the core (via the
++     extended NT_PRSTATUS note); the loadmap *contents* live in a
++     PT_LOAD segment.  Read the address from .reg, then reuse
++     fetch_loadmap() which walks target memory.  */
++  if (core_bfd != NULL)
++    {
++      CORE_ADDR ldm_addr = fdpic_core_loadmap_addr (is_interpreter);
++      if (ldm_addr == 0)
++	{
++	  if (!is_interpreter)
++	    error (_("Error reading FDPIC exec loadmap from core"));
++	  return NULL;
++	}
++      struct int_elf32_fdpic_loadmap *res = fetch_loadmap (ldm_addr);
++      if (solib_fdpic_debug)
++	dump_loadmap (res);
++      return res;
++    }
++
+   gdb::optional<gdb::byte_vector> buf
+     = target_read_alloc (current_inferior ()->top_target (),
+ 			 TARGET_OBJECT_FDPIC,
+ 			 is_interpreter ? "interp" : "exec");
+   struct int_elf32_fdpic_loadmap *res;
+ 
+-  if (solib_fdpic_debug)
+-    fprintf_unfiltered (gdb_stdlog, "  %s : %d\n", __FUNCTION__, is_interpreter);
+-
+   /* Read raw loadmap.  */
+   if (!buf || buf->empty ())
+     {
+@@ -435,7 +487,9 @@
+   if (solib_fdpic_debug)
+     fprintf_unfiltered (gdb_stdlog, " %s\n", __FUNCTION__);
+ 
+-  if (!target_has_execution ())
++  /* Allow core-file debugging to proceed; rm7087 guard only needs to
++     skip the "file <exec>" / no-target case.  */
++  if (!target_has_execution () && core_bfd == NULL)
+     return;
+ 
+   /* Get interpreter loadmap to see if we have a static or dynamic binary.  */
+-- 
+2.34.1

--- a/package/gdb/11.2/0022-RM-7623-gdb-arm-linux-tdep-widen-.reg-size-for-FDPIC-core-dumps.patch
+++ b/package/gdb/11.2/0022-RM-7623-gdb-arm-linux-tdep-widen-.reg-size-for-FDPIC-core-dumps.patch
@@ -1,0 +1,41 @@
+From: Vladimir Skvortsov <vskvortsov@emcraft.com>
+Subject: [PATCH] RM-7623: gdb/arm-linux-tdep: widen .reg size for FDPIC core dumps
+
+After 0020-... teaches BFD to produce an 80-byte .reg pseudosection
+for FDPIC core dumps, GDB's generic core-section validator compares
+the section's actual size (80) against the size advertised by
+arm_linux_iterate_over_regset_sections (72) and prints:
+
+    warning: Unexpected size of section `.reg/<lwp>' in core file.
+
+The warning is harmless -- arm_linux_supply_gregset reads only the
+first 72 bytes and the trailing 8 bytes are consumed by solib-fdpic
+-- but it clutters every post-mortem session.  Advertise
+ARM_LINUX_SIZEOF_GREGSET + 8 when the gdbarch is FDPIC so the two
+sizes agree.
+
+Signed-off-by: Vladimir Skvortsov <vskvortsov@emcraft.com>
+---
+--- a/gdb/arm-linux-tdep.c
++++ b/gdb/arm-linux-tdep.c
+@@ -776,7 +776,17 @@
+ {
+   struct gdbarch_tdep *tdep = gdbarch_tdep (gdbarch);
+ 
+-  cb (".reg", ARM_LINUX_SIZEOF_GREGSET, ARM_LINUX_SIZEOF_GREGSET,
++  /* On FDPIC the kernel writes struct elf_prstatus_fdpic, which inserts
++     pr_exec_fdpic_loadmap and pr_interp_fdpic_loadmap (2 * 4 bytes)
++     between pr_reg and pr_fpvalid.  The BFD backend exposes those
++     trailing bytes as part of .reg (see bfd/elf32-arm.c, case 156), so
++     advertise the larger size here to match and avoid the
++     "Unexpected size of section `.reg/<lwp>'" warning.  The supply
++     callback reads only the first 72 bytes; the extra 8 are consumed
++     by solib-fdpic.  */
++  int gregset_size = ARM_LINUX_SIZEOF_GREGSET + (tdep->is_fdpic ? 8 : 0);
++
++  cb (".reg", gregset_size, gregset_size,
+       &arm_linux_gregset, NULL, cb_data);
+ 
+   if (tdep->vfp_register_count > 0)
+-- 
+2.34.1

--- a/package/gdb/11.2/0023-RM-7623-gdb-arm-tdep-propagate-Cortex-M-profile-into-core-dump-gdbarch.patch
+++ b/package/gdb/11.2/0023-RM-7623-gdb-arm-tdep-propagate-Cortex-M-profile-into-core-dump-gdbarch.patch
@@ -1,0 +1,133 @@
+From: Vladimir Skvortsov <vskvortsov@emcraft.com>
+Subject: [PATCH] RM-7623: gdb/arm-tdep: propagate Cortex-M profile into core-dump gdbarch
+
+arm_gdbarch_init decides `is_m' (Cortex-M) by (a) the Cortex-M feature
+in a target description or (b) the ARM build attributes on
+`info.abfd'.  Neither path fires in a post-mortem FDPIC session:
+
+  1. gdbserver is not involved, so there is no m-profile tdesc.  The
+     core target synthesises a generic "org.gnu.gdb.arm.core" tdesc
+     (with cpsr) from the NT_PRSTATUS note, but that feature contains
+     no M-profile marker.
+  2. The Linux FDPIC core dumper (fs/binfmt_elf_fdpic.c with
+     ELF_FDPIC_CORE_EFLAGS == 0) writes a bare ELF with e_flags = 0
+     and no .ARM.attributes section, so Tag_CPU_arch and
+     Tag_CPU_arch_profile read 0 from the core bfd.
+  3. The existing BFD-attribute path for is_m is additionally gated
+     by `!tdesc_has_registers(tdesc)', so even the executable's
+     build attributes on the exec bfd would not reach it once the
+     core target has installed its synthetic arm.core tdesc.
+
+With is_m left false, arm_psr_thumb_bit returns CPSR_T (0x20)
+instead of XPSR_T (0x01000000).  The saved xPSR in pr_reg reads
+0x01000000 (bit 24 set, bit 5 clear), so arm_frame_is_thumb returns
+false for every Thumb PC, arm_scan_prologue runs the ARM-mode
+analyser against Thumb bytes, fails to recognise the prologue, and
+leaves cache->saved_regs in its initial is_realreg state.
+trad_frame_get_prev_register then hands back the current frame's
+pr_reg register values as the caller's registers, so post-mortem
+`bt' stops one frame past the innermost libc entry with
+"previous frame inner to this frame (corrupt stack?)" and any
+argument read through the bogus frame pointer fails with
+"Cannot access memory at address ...".
+
+Fix in three coordinated pieces:
+
+  * When `info.abfd' has no ARM build attributes, fall back to
+    `current_program_space->exec_bfd ()'.  GCC copies
+    Tag_CPU_arch_profile='M' into the executable, so the exec
+    provides the missing tag for cores.
+
+  * Remove the `!tdesc_has_registers(tdesc)' guard from the BFD
+    attribute check.  The build attribute is authoritative: it
+    should promote is_m whether or not the core session happens
+    to carry a synthetic tdesc.
+
+  * Teach the tdesc register-validation block to accept either
+    "xpsr" or "cpsr" for ARM_PS_REGNUM when is_m is true.  A
+    Cortex-M binary with the generic arm.core feature names the
+    PS register "cpsr", and without this fallback the M-profile
+    check would make gdbarch_find_by_info return NULL.
+
+With the fix the gdbarch selected for the core is Cortex-M
+(arm_psr_thumb_bit returns XPSR_T), arm_frame_is_thumb correctly
+identifies Thumb frames, the prologue analyser populates
+cache->saved_regs, and post-mortem `bt' walks the full call chain
+the same way a live gdbserver session does.
+
+Signed-off-by: Vladimir Skvortsov <vskvortsov@emcraft.com>
+---
+--- a/gdb/arm-tdep.c
++++ b/gdb/arm-tdep.c
+@@ -9064,14 +9064,44 @@
+ 		= bfd_elf_get_obj_attr_int (info.abfd, OBJ_ATTR_PROC,
+ 					    Tag_CPU_arch_profile);
+ 
++	      /* Core files written by the Linux FDPIC core dumper carry
++		 no .ARM.attributes section (the kernel sets
++		 ELF_FDPIC_CORE_EFLAGS = 0 and does not copy build
++		 attributes into the core), so info.abfd returns 0 for
++		 both tags above.  Fall back to the current exec bfd --
++		 GCC does copy the attributes into the executable -- so
++		 the M-profile discriminator below still fires for
++		 post-mortem Cortex-M sessions.  */
++	      if (attr_arch == 0 && attr_profile == 0
++		  && current_program_space->exec_bfd () != NULL
++		  && current_program_space->exec_bfd () != info.abfd)
++		{
++		  bfd *exec = current_program_space->exec_bfd ();
++		  attr_arch
++		    = bfd_elf_get_obj_attr_int (exec, OBJ_ATTR_PROC,
++						Tag_CPU_arch);
++		  attr_profile
++		    = bfd_elf_get_obj_attr_int (exec, OBJ_ATTR_PROC,
++						Tag_CPU_arch_profile);
++		}
++
+ 	      /* GCC specifies the profile for v6-M; RealView only
+ 		 specifies the profile for architectures starting with
+ 		 V7 (as opposed to architectures with a tag
+-		 numerically greater than TAG_CPU_ARCH_V7).  */
+-	      if (!tdesc_has_registers (tdesc)
+-		  && (attr_arch == TAG_CPU_ARCH_V6_M
+-		      || attr_arch == TAG_CPU_ARCH_V6S_M
+-		      || attr_profile == 'M'))
++		 numerically greater than TAG_CPU_ARCH_V7).
++
++		 The M-profile tag is authoritative even when a tdesc is
++		 present: core sessions synthesize a generic
++		 org.gnu.gdb.arm.core tdesc (with cpsr) for Cortex-M
++		 binaries, and without letting the BFD attribute promote
++		 is_m here arm_psr_thumb_bit picks CPSR_T instead of
++		 XPSR_T, misreading xPSR and forcing arm_frame_is_thumb
++		 to false for Thumb code.  The register-validation block
++		 below accepts either cpsr or xpsr naming when is_m is
++		 true, so this promotion is safe.  */
++	      if (attr_arch == TAG_CPU_ARCH_V6_M
++		  || attr_arch == TAG_CPU_ARCH_V6S_M
++		  || attr_profile == 'M')
+ 		is_m = true;
+ #endif
+ 	    }
+@@ -9149,8 +9179,17 @@
+ 						  ARM_PC_REGNUM,
+ 						  arm_pc_names);
+       if (is_m)
+-	valid_p &= tdesc_numbered_register (feature, tdesc_data.get (),
+-					    ARM_PS_REGNUM, "xpsr");
++	{
++	  /* Prefer the M-profile "xpsr" name, but a core file may supply
++	     the generic org.gnu.gdb.arm.core feature (with "cpsr") even
++	     for a Cortex-M binary; accept either so the M-profile
++	     discriminator (is_m) still applies and arm_psr_thumb_bit
++	     returns XPSR_T.  */
++	  if (!tdesc_numbered_register (feature, tdesc_data.get (),
++					ARM_PS_REGNUM, "xpsr"))
++	    valid_p &= tdesc_numbered_register (feature, tdesc_data.get (),
++						ARM_PS_REGNUM, "cpsr");
++	}
+       else
+ 	valid_p &= tdesc_numbered_register (feature, tdesc_data.get (),
+ 					    ARM_PS_REGNUM, "cpsr");
+--
+2.34.1


### PR DESCRIPTION
Unit test as per https://voxelbotics.atlassian.net/wiki/spaces/IRD/pages/1451786243/Debugging+with+ELF+Core+Dumps+on+i.MX+RT+Targets